### PR TITLE
adding conditions to screenshare for firefox

### DIFF
--- a/js/opentok.js-annotations/templates/screenshare.html
+++ b/js/opentok.js-annotations/templates/screenshare.html
@@ -33,6 +33,12 @@
 
     };
 
+    if(navigator.userAgent.indexOf("Firefox") != -1 ){
+      var ghost = window.open("about:blank");
+      ghost.focus();
+      ghost.close();
+    }
+
 </script>
 
 <style type="text/css" media="screen">


### PR DESCRIPTION
This is to be able to return focus to the parent when using Screenshare extension in Firefox

//cc @adrice727  @Lucashuang0802 @marinaserranomontes 