### PR TITLE
Use subscriber connection Id for the param 'Id' on the signal.

### DIFF
--- a/android/AnnotationsKit/annotations-kit/src/main/java/com/tokbox/android/annotations/AnnotationsView.java
+++ b/android/AnnotationsKit/annotations-kit/src/main/java/com/tokbox/android/annotations/AnnotationsView.java
@@ -88,6 +88,7 @@ public class AnnotationsView extends ViewGroup implements AnnotationsToolbar.Act
     private boolean defaultLayout = false;
 
     private AccPackSession mSession;
+    private String mRemoteConnectionId;
     private String mPartnerId;
 
     private OTKAnalyticsData mAnalyticsData;
@@ -183,6 +184,23 @@ public class AnnotationsView extends ViewGroup implements AnnotationsToolbar.Act
      */
     public AnnotationsView(Context context, AttributeSet attrs) {
         super(context, attrs);
+        init();
+    }
+
+    /*
+     * Constructor
+     * @param context Application context
+     * @param session The OpenTok Accelerator Pack session instance.
+     * @param partnerId  The partner id - apiKey.
+     **/
+    public AnnotationsView(Context context, AccPackSession session, String partnerId, boolean isScreensharing, ViewType type, String remoteConnectionId) {
+        super(context);
+        this.mContext = context;
+        this.mSession = session;
+        this.mPartnerId = partnerId;
+        this.mSession.setSignalListener(this);
+        this.isScreensharing = isScreensharing;
+        this.mRemoteConnectionId = remoteConnectionId;
         init();
     }
 
@@ -841,7 +859,7 @@ public class AnnotationsView extends ViewGroup implements AnnotationsToolbar.Act
             videoHeight = videoRenderer.getVideoHeight();
         }
         try {
-            jsonObject.put("id", mSession.getConnection().getConnectionId());
+            jsonObject.put("id", mRemoteConnectionId);
             jsonObject.put("fromId", mSession.getConnection().getConnectionId());
             jsonObject.put("fromX", mCurrentPath.getEndPoint().x);
             jsonObject.put("fromY", mCurrentPath.getEndPoint().y);


### PR DESCRIPTION
This PR adds a new constructor to receive the subscriber. This way we can get the remote connectionId and use it on the signal. Not sure if we need to receive the subscriber or just the connectionId as a string. I chose to receive the object just in case we need more info from the subscriber. 

@marinaserranomontes Please review this PR. Thanks!