### PR TITLE
[OTS-680] Co-browsing does not draw under a circumstance.

### DIFF
--- a/ios/AnnotationAccPackKit/OTAnnotationKit/OTAnnotator.m
+++ b/ios/AnnotationAccPackKit/OTAnnotationKit/OTAnnotator.m
@@ -531,7 +531,7 @@ receivedSignalType:(NSString*)type
     if (signalingPoints.count == 5) {
         NSError *error;
         NSString *jsonString = [JSON stringify:signalingPoints];
-        [self.session signalWithType:@"otAnnotation_pen" string:jsonString connection:latestScreenShareStream.connection error:&error];
+        [self.session signalWithType:@"otAnnotation_pen" string:jsonString connection:nil error:&error];
         
         // notify sending data
         if (self.dataReceivingHandler) {
@@ -563,7 +563,7 @@ receivedSignalType:(NSString*)type
     
     NSError *error;
     NSString *jsonString = [JSON stringify:signalingPoints];
-    [self.session signalWithType:@"otAnnotation_pen" string:jsonString connection:latestScreenShareStream.connection error:&error];
+    [self.session signalWithType:@"otAnnotation_pen" string:jsonString connection:nil error:&error];
     
     // notify sending data
     if (self.dataReceivingHandler) {


### PR DESCRIPTION
## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts. Confirmation: ok

#### This fixes issue #680.
[OTS-680] Co-browsing does not draw under a circumstance.
## What's in this pull request?

> By German suggestion: We detected that this bug occurs “randomly”. Sometimes web doesn’t receive the  signal. Theoretically you need to remove the connection on this line. We think that  sometimes is wrong, so web is not receiving the signal. We replace that for `nil`  and it started to work on all the tests.
> Tested with Andrea y German. Andrea: its probably gonna be useful for multiparty as well because if you have a connection then its gonna restrict the signaling to it, you need to send it to all in the session.

