### PR TITLE
[OTS-694] Increment to 1.2.0-beta9.

### DIFF
--- a/ios/AnnotationAccPackKit/OTAnnotationKit.podspec
+++ b/ios/AnnotationAccPackKit/OTAnnotationKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "OTAnnotationKit"
-  s.version          = "1.2.0-beta8"
+  s.version          = "1.2.0-beta9"
   s.summary          = "OpenTok Annotations Accelerator Pack enables users to annotate their screens."
 
   s.description      = "This document describes how to use the OpenTok Annotations Accelerator Pack for iOS. Through the exploration of the OpenTok Annotations Sample App, you will learn best practices for annotating on an iOS mobile device."
@@ -32,5 +32,5 @@ Pod::Spec.new do |s|
     'ios/AnnotationAccPackKit/OTAnnotationKit/OTAnnotationUI/Toolbar/OTAnnotationToolbarView.h'
 
   s.dependency 'LHToolbar', '1.3.0-beta'
-  s.dependency 'OTAcceleratorPackUtil', '2.0.0-beta4'
+  s.dependency 'OTAcceleratorPackUtil', '2.0.0-beta5'
 end


### PR DESCRIPTION
dependency OTAcceleratorPackUtil incremented to 2.0.0-beta5

@Lucashuang0802 I'll need this dependency incremented.

This PR depends of the approval of OTAcceleratorPackUtil: https://github.com/opentok/acc-pack-common/pull/65